### PR TITLE
Fix Prisma query to use published field instead of status

### DIFF
--- a/app/api/blogs/route.ts
+++ b/app/api/blogs/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
     // Get posts directly from the database using Prisma
     const posts = await prisma.post.findMany({
       where: {
-        status: 'published'
+        published: true
       },
       orderBy: {
         createdAt: 'desc'


### PR DESCRIPTION
Fix Prisma query to use published field instead of status